### PR TITLE
Update extension for Steal ^0.12 compatibility

### DIFF
--- a/cache-bust.js
+++ b/cache-bust.js
@@ -1,6 +1,6 @@
 var loader = require("@loader");
 
-if(loader.env === "production") {
+if(isProduction()) {
 	cacheBust();
 }
 
@@ -23,4 +23,9 @@ function cacheBust(){
 			return proposedAddress;
 		});
 	};
+}
+
+function isProduction(){
+	return (loader.isEnv && loader.isEnv("production")) ||
+		loader.env === "production";
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/stealjs/cache-bust",
   "devDependencies": {
-    "steal": "^0.10.5",
-    "steal-qunit": "0.0.4",
+    "steal": "^0.13.0-pre.0",
+    "steal-qunit": "^0.1.0",
     "testee": "^0.2.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,7 @@ QUnit.module("cache-bust", {
 
 		loader = loader.clone();
 		loader.set("@loader", loader.newModule({ default: loader, __useDefault: true }));
-		loader.env = "production";
+		loader.env = "window-production";
 
 		delete loader.cacheKey;
 		delete loader.cacheVersion;


### PR DESCRIPTION
Use `System.isEnv` if available. For #2
