### PR TITLE
- using fetch to perform cache busting

### DIFF
--- a/cache-bust.js
+++ b/cache-bust.js
@@ -1,16 +1,14 @@
 var loader = require("@loader");
 var fetch = loader.fetch;
 var timestamp = new Date().getTime();
-var cacheVersion = isProduction() ? loader.cacheVersion || timestamp : timestamp;
-var cacheKey = loader.cacheKey || "version";
-var cacheKeyVersion = cacheKey + "=" + cacheVersion;
 
 loader.fetch = function(load) {
-	if(!load.metadata.plugin || load.metadata.cacheInitial) {
-		load.address = load.address + (load.address.indexOf('?') === -1 ? '?' : '&') + cacheKeyVersion;
-	} else if(load.metadata.plugin) {
-		load.metadata.cacheInitial = true;
-	}
+	var loader = this;
+	var cacheVersion = isProduction() ? loader.cacheVersion || timestamp : timestamp;
+	var cacheKey = loader.cacheKey || "version";
+	var cacheKeyVersion = cacheKey + "=" + cacheVersion;
+
+	load.address = load.address + (load.address.indexOf('?') === -1 ? '?' : '&') + cacheKeyVersion;
 
 	return fetch.call(this, load);
 };

--- a/test/test.js
+++ b/test/test.js
@@ -6,16 +6,16 @@ var stop = QUnit.stop;
 var start = QUnit.start;
 var equal = QUnit.equal;
 
-function wrapLocate(callback){
-	var locate = loader.locate;
-	loader.locate = function(){
-		return locate.apply(this, arguments).then(function(address){
-			callback(address);
-			return address;
+function wrapFetch(callback){
+	var fetch = loader.fetch;
+	loader.fetch = function(load){
+		return fetch.apply(this, arguments).then(function(source){
+			callback(load.address);
+			return source;
 		});
 	};
 	loader.unwrap = function(){
-		loader.locate = locate;
+		loader.fetch = fetch;
 	};
 }
 
@@ -43,7 +43,7 @@ QUnit.module("cache-bust", {
 test("basics works", function(){
 	expect(1);
 
-	wrapLocate(function(address){
+	wrapFetch(function(address){
 		var query = getQuery(address);
 		var version = query.split("=")[1];
 
@@ -60,7 +60,7 @@ test("basics works", function(){
 test("Overriding the cacheKey works", function(){
 	expect(1);
 
-	wrapLocate(function(address){
+	wrapFetch(function(address){
 		var query = getQuery(address);
 		var key = query.split("=")[0];
 
@@ -77,7 +77,7 @@ test("Overriding the cacheKey works", function(){
 test("works with plugins too", function(){
 	expect(2);
 
-	wrapLocate(function(address){
+	wrapFetch(function(address){
 		if(address.indexOf("?") > 0) {
 			var query = getQuery(address);
 			var parts = query.split("=");


### PR DESCRIPTION
Hi Mathew,

I changed the code to use the `fetch` hook as the `locate` hook seemed to not contain the full url but rather the module name in some relevant instances.

For production: If there is no `cache-version` specified then the timestamp will be used as the version.
In development: the timestamp is _always_ used as the version.

However, there appear to be quite a number of files not passing through the hook.  I figure it has to do with other modules working outside of the steal space so those are pretty much beyond steal's control.

Regards,
Eben
