### PR TITLE
- fixed build issue

### DIFF
--- a/cache-bust.js
+++ b/cache-bust.js
@@ -2,14 +2,24 @@ var loader = require("@loader");
 var fetch = loader.fetch;
 var timestamp = new Date().getTime();
 
+var isBuildEnvironment = loader.isPlatform ?
+	(loader.isPlatform("build") || loader.isEnv("build")) :
+	(typeof window === "undefined");
+
 loader.fetch = function(load) {
 	var loader = this;
-	var cacheVersion = isProduction() ? loader.cacheVersion || timestamp : timestamp;
-	var cacheKey = loader.cacheKey || "version";
-	var cacheKeyVersion = cacheKey + "=" + cacheVersion;
+	var cacheVersion;
+	var cacheKey;
+	var cacheKeyVersion;
+	
+	if (!isBuildEnvironment) {
+		cacheVersion = isProduction() ? loader.cacheVersion || timestamp : timestamp;
+		cacheKey = loader.cacheKey || "version";
+		cacheKeyVersion = cacheKey + "=" + cacheVersion;
 
-	load.address = load.address + (load.address.indexOf('?') === -1 ? '?' : '&') + cacheKeyVersion;
-
+		load.address = load.address + (load.address.indexOf('?') === -1 ? '?' : '&') + cacheKeyVersion;
+	}
+	
 	return fetch.call(this, load);
 };
 	


### PR DESCRIPTION
Hi Matthew,

I noticed in the readme.md (that I'll update and add another PR) that you mention that cache-bust should be copied to some location within one's project structure.  Why is that?  Would it not be included if referenced from within the node_modules folder?  I'd like to add something to the readme.md about that to make it absolutely clear.  Currently I don't have cache-bust in my project structure (only in node_modules) and this meant change the configDependencies to point to the full path: "node_modules/steal-cache-bust/cache-bust"

Anyway, the `isPlatform('build')` didn't work by its lonesome but I found the `isBuildEnvironment` bit in the live-reload.js file and it seems to work OK :)

Regards,
Eben
