### PR TITLE
Add a deprecation notice to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
-[![Build Status](https://travis-ci.org/stealjs/cache-bust.svg?branch=master)](https://travis-ci.org/stealjs/cache-bust)
-[![npm version](https://badge.fury.io/js/steal-cache-bust.svg)](http://badge.fury.io/js/steal-cache-bust)
-
 # cache-bust
 
+[![Join our Slack](https://img.shields.io/badge/slack-join%20chat-611f69.svg)](https://www.bitovi.com/community/slack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join our Discourse](https://img.shields.io/discourse/https/forums.bitovi.com/posts.svg)](https://forums.bitovi.com/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/stealjs/steal/blob/master/license.md)
+[![npm version](https://badge.fury.io/js/steal-cache-bust.svg)](http://badge.fury.io/js/steal-cache-bust)
+[![Build Status](https://travis-ci.org/stealjs/cache-bust.svg?branch=master)](https://travis-ci.org/stealjs/cache-bust)
+[![Greenkeeper badge](https://badges.greenkeeper.io/stealjs/cache-bust.svg)](https://greenkeeper.io/)
+
 A StealJS and SystemJS cache busting extension.
+
+> **Deprecated:** this package is now built into [steal](https://github.com/stealjs/steal/). See the [cacheVersion](https://stealjs.com/docs/config.cacheVersion.html) documentation for more details.
 
 # Install
 


### PR DESCRIPTION
I always forget that this package was moved into core. https://github.com/stealjs/steal/pull/1015